### PR TITLE
add OpenCV_INCLUDE_DIRS to inlude_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ endif()
 
 set(MYNTEYE_LINKLIBS ${UVC_LIB})
 if(WITH_API)
+  include_directories(${OpenCV_INCLUDE_DIRS})
   list(APPEND MYNTEYE_LINKLIBS ${OpenCV_LIBS})
 endif()
 if(WITH_BOOST_FILESYSTEM)


### PR DESCRIPTION
Tested on ubuntu 16.04 with ros kinetic.  System installed both opencv 2.4 and opencv 3.3.1. The header file location, opencv2.4 was in the /usr/include, opencv 3.3.1 was in the /opt/ros/kinetic/include/opencv-3.3.1.
When  OpenCV_INCLUDE_DIRS was not added ,  the project would use the opencv2.4 header files even   with opencv3.3.1 was detected by find_package.