### PR TITLE
running multiple devices with integer serial-number

### DIFF
--- a/wrappers/ros/src/mynt_eye_ros_wrapper/launch/mynteye.launch
+++ b/wrappers/ros/src/mynt_eye_ros_wrapper/launch/mynteye.launch
@@ -53,7 +53,7 @@
       <!-- node params -->
 
       <param name="is_multiple" value="$(arg is_multiple)" />
-      <param name="serial_number" value="$(arg serial_number)" />
+      <param name="serial_number" value="$(arg serial_number)" type="str"/>
 
       <param name="depth_type" value="$(arg depth_type)" />
 


### PR DESCRIPTION
when running with multiple devices, if one device has the serial number that only contains digits (very rare), it will automatically casted to int (which gave overflow error). You have to explicitly set the type in to string in the launch file. 